### PR TITLE
Auto-Merge Dependabot Findings

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,3 @@
+- match:
+  dependency_type: all
+  update_type: "semver:minor"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: 'Auto Merge Dependabot PRs'
+on:
+  pull_request:
+
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.TOKEN }}


### PR DESCRIPTION
## Add workflow to auto-merge

Dependabot findings are a PITA. One the one side, they're super useful, because, let's face it, otherwise no one would update dependencies.
On the other hand, though, they're annoying because there are so many of them.

The solutoin is simple:
--> Auto merge dependabot findings, if they pass CI/CD